### PR TITLE
added python2 Shebang

### DIFF
--- a/magic_bypass.py
+++ b/magic_bypass.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2.7
 import binascii
 import os
 import sys


### PR DESCRIPTION
As python3 became the default for Kali-Linux, executing the script directly with ./magic_bypass.py or from PATH causes an error.